### PR TITLE
Add Codewars leaderboard project

### DIFF
--- a/Project-Codewars-Leaderboard/README.md
+++ b/Project-Codewars-Leaderboard/README.md
@@ -59,4 +59,10 @@ All of the below requirements must be met for the project to be considered compl
 
 Below is an example of a table showing the overall ranking for 3 users: CodeYourFuture, SallyMcGrath and 40thieves.
 
+| Username       | Clan           | Score |
+| -------------- | -------------- | ----- |
+| SallyMcGrath   | CodeYourFuture | 1079  |
+| CodeYourFuture | CodeYourFuture | 751   |
+| 40thieves      |                | 10    |
+
 Please note that the individual ranks/scores shown in the above table may not be accurate as they may change if new katas are completed by these accounts. To see up-to-date data, you can look it up in the API responses: [CodeYourFuture](https://www.codewars.com/api/v1/users/CodeYourFuture), [SallyMcGrath](https://www.codewars.com/api/v1/users/SallyMcGrath), [40thieves](https://www.codewars.com/api/v1/users/40thieves).

--- a/Project-Codewars-Leaderboard/README.md
+++ b/Project-Codewars-Leaderboard/README.md
@@ -1,0 +1,62 @@
+# Codewars Leaderboard project
+
+Codewars provides [an API](https://dev.codewars.com/) that can be used to look up an individual user's rank and score.
+
+We will use this to build a leaderboard, similar to [the one on the Codewars website](https://www.codewars.com/users/leaderboard/ranks).
+
+Your task is to create a website which allows a user to input a list of Codewars users, fetch their scores from the API and then display them so that you can compare. You should **focus on HTML and JavaScript**. Some CSS is required for completing this task, but the website's design **is not the focus of the assessment**. We will assess you on correct logic not on a perfect UI that is incomplete.
+
+## Requirements
+
+<!-- TODO: Decide whether this is an individual or group project, then include instructions here -->
+
+You must submit both a link to your GitHub repo, and a link to the deployed website.
+
+Your website must be hosted on the internet, and must be automatically deployed when you merge changes to your GitHub repo.
+
+You must be able to explain every line of code in your project, even ones other people in your group wrote.
+
+You should assume that Codewars ranks will change in the future. So you **must not** pre-compute anything. Your code should always read the data and calculate results from scratch.
+
+Your website should display an input, allowing the user to add a comma-separated list of Codewars usernames (e.g. "CodeYourFuture,40thieves,SallyMcGrath") that they want to display on the leaderboard.
+
+You **must not** implement any kind of authentication or data storage. Just a form to pick which usernames to display on the leaderboard.
+
+When a user is happy with the list of usernames, they can trigger your website to fetch data from the [Get User endpoint of the Codewars API](https://dev.codewars.com/#get-user). Within this data, each user has a `ranks` property which should be used to calculate their ranking.
+
+Using the leaderboard ranking data, your website should calculate all of the possible languages that the users have a ranking in. Your website should show a drop-down allowing the user to pick from all of these language rankings, plus the overall ranking.
+
+Your website should display a table for the ranking data that the user has selected from the drop-down. The table should default to showing the overall ranking if a language has not been selected yet. If the user selects another language from the drop-down, the table should show it's ranking data.
+
+The table should have columns for username, clan and score. Each user should have a row in the table showing their relevant data points for selected language ranking. The rows should be sorted so that the user with the highest score for the selected language ranking is at the top, and the user with the lowest score is at the bottom.
+
+The user with the highest score should be highlighted in some (fun!) way so that their achievement can be celebrated.
+
+Your GitHub repository must contain unit tests which demonstrate that your code works.
+
+### Supplied test scaffolding
+
+A test demonstrating the usage of the [nock testing library](https://github.com/nock/nock) has been provided for you. This library is helpful for replacing `fetch` calls with "mocked" data, allowing you to control the test fully.
+
+You **must** run `npm install` within the `Project-Codewars-Leaderboard` folder in order for the scaffolding to work.
+
+Running `node index.test.mjs` (within the `Project-Codewars-Leaderboard` folder) will run the tests.
+
+## Rubric
+
+All of the below requirements must be met for the project to be considered complete:
+
+- The website must contain an input to accept a comma-separated list of users
+- Submitting the list of users fetches data from the Codewars API about each of the users
+- Based on the leaderboard data, a drop-down is shown, allowing the user to pick from all of the possible language rankings plus the overall ranking
+- The default ranking selected is the overall ranking
+- A table is shown for the current ranking, with columns for each user's username, clan and score
+- Changing the selected ranking will update the table to reflect the newly selected ranking
+- The table is sorted from the highest to lowest score, top to bottom
+- The top user's score is visually highlighted
+- The website must score 100 for accessibility in Lighthouse
+- Unit tests must be written for at least one non-trivial function
+
+Below is an example of a table showing the overall ranking for 3 users: CodeYourFuture, SallyMcGrath and 40thieves.
+
+Please note that the individual ranks/scores shown in the above table may not be accurate as they may change if new katas are completed by these accounts. To see up-to-date data, you can look it up in the API responses: [CodeYourFuture](https://www.codewars.com/api/v1/users/CodeYourFuture), [SallyMcGrath](https://www.codewars.com/api/v1/users/SallyMcGrath), [40thieves](https://www.codewars.com/api/v1/users/40thieves).

--- a/Project-Codewars-Leaderboard/index.html
+++ b/Project-Codewars-Leaderboard/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Codewars leaderboard</title>
+</head>
+<body>
+  
+</body>
+
+<script src="index.mjs" type="module"></script>
+</html>

--- a/Project-Codewars-Leaderboard/index.mjs
+++ b/Project-Codewars-Leaderboard/index.mjs
@@ -1,0 +1,8 @@
+// This is a placeholder file to show how you can "mock" fetch requests using
+// the nock library.
+// You can delete the contents of the file once you have understood how it
+// works.
+
+export function makeFetchRequest() {
+  return fetch("https://example.com/test");
+}

--- a/Project-Codewars-Leaderboard/index.test.mjs
+++ b/Project-Codewars-Leaderboard/index.test.mjs
@@ -1,0 +1,30 @@
+// This is a placeholder file which shows how you use the nock library to
+// "mock" fetch requests, replacing real requests with fake ones that you
+// control in the test. This means you can "force" the fetch request to return
+// data in the format that you want.
+// IMPORTANT: You _must_ run npm install within the Project-Codewars-Leaderboard
+// folder for this to work.
+// You can delete the contents of the file once you have understood how it
+// works.
+
+import test from "node:test";
+import assert from "node:assert";
+import nock from "nock";
+import { makeFetchRequest } from "./index.mjs";
+
+test("mocks a fetch function", async () => {
+  // Create a fetch request "mock" using the nock library, which "replaces"
+  // real requests with fake ones that we can control in the test using nock
+  // functions.
+  // In this example, we set up nock so that it looks for GET requests to
+  // https://example.com/test (no other URLs will work) and responds with a 200
+  // HTTP status code.
+  const scope = nock("https://example.com").get("/test").reply(200);
+
+  await makeFetchRequest();
+
+  // Ensure that a fetch request has been replaced by the nock library. This
+  // helps ensure that you're not making real fetch requests that don't match
+  // the nock configuration.
+  assert(scope.isDone() === true, "No matching fetch request has been made");
+});

--- a/Project-Codewars-Leaderboard/package-lock.json
+++ b/Project-Codewars-Leaderboard/package-lock.json
@@ -1,0 +1,98 @@
+{
+  "name": "Project-Codewars-Leaderboard",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "nock": "^14.0.0-beta.15"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.36.10",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.36.10.tgz",
+      "integrity": "sha512-GXrJgakgJW3DWKueebkvtYgGKkxA7s0u5B0P5syJM5rvQUnrpLPigvci8Hukl7yEM+sU06l+er2Fgvx/gmiRgg==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
+    "node_modules/nock": {
+      "version": "14.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.15.tgz",
+      "integrity": "sha512-rp72chatxoZbR/2cYHwtb+IX6n6kkanYKGN2PKn4c12JBrj9n4xGUKFykuQHB+Gkz3fynlikFbMH2LI6VoebuQ==",
+      "dev": true,
+      "dependencies": {
+        "@mswjs/interceptors": "^0.36.4",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
+    }
+  }
+}

--- a/Project-Codewars-Leaderboard/package.json
+++ b/Project-Codewars-Leaderboard/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "nock": "^14.0.0-beta.15"
+  }
+}


### PR DESCRIPTION
## Changelist

Adds a Codewars leaderboard project, based on Sally's [ideas doc](https://docs.google.com/document/d/13l0Btv1LMFnFL40JHq6yFjBkCl5GglolIrqJnqHgUk0/edit?tab=t.0).

I've made some assumptions about how the API/ranking should work, since it appears the `ranks.rank` value provided in the API seems to be related to badging in a way that I don't fully understand. Essentially, I'm relying solely on the `ranks.score` value to determine who is leading. But happy to change this if I've misunderstood the API.

One of the main issues I ran into writing this up was that I can easily imagine trainees getting into trouble by their tests making actual fetch requests. I've therefore scaffolded out a test with mocking via `nock`, and done my best to document what this is doing and how they can use it. However, I'm fairly conscious introducing the concept of mocking might be a giant rabbithole that we don't want to get into as part of the assessment.

It might be simplest to just write up some advice about avoiding testing of anything involving fetch - but this relies on the assumption that trainees would be able to break up their code in such a way that they can test these pieces independently.

I'm also slightly on the fence about how I've framed the "Celebrate the leader in some dynamic fun way" point from Sally's suggestion. I've tried to downplay this as a hard-requirement, much with several of our other tasks, I expect the emphasis of our assessment will be on the logic, not styling.