### PR TITLE
Fix add data

### DIFF
--- a/Project-Spaced-Repetition-Tracker/storage.js
+++ b/Project-Spaced-Repetition-Tracker/storage.js
@@ -30,7 +30,7 @@ export function getData(userId) {
 export function addData(userId, data) {
   const key = `stored-data-user-${userId}`;
 
-  const existingData = localStorage.getItem(key) || [];
+  const existingData = getData(userId) || [];
   const newData = existingData.concat(data);
 
   localStorage.setItem(key, JSON.stringify(newData));


### PR DESCRIPTION
Before it wasn't JSON-parsing the existing input, so the second add would end up adding `[Object object]` at the end of the JSON string.