### PR TITLE
Use absolute links in readmes

### DIFF
--- a/Project-Days-Calendar/README.md
+++ b/Project-Days-Calendar/README.md
@@ -114,4 +114,4 @@ Text for Ada Lovelace Day (which must be fetched via API):
 
 ## Working in a group
 
-If you working in a group, we recommend that **all** team members read the [Working in a group guidelines](../working-in-a-group.md). Confirm all group members have read and understand these before starting to write code.
+If you working in a group, we recommend that **all** team members read the [Working in a group guidelines](https://github.com/CodeYourFuture/The-Piscine/blob/main/working-in-a-group.md). Confirm all group members have read and understand these before starting to write code.

--- a/Project-Spaced-Repetition-Tracker/README.md
+++ b/Project-Spaced-Repetition-Tracker/README.md
@@ -128,4 +128,4 @@ Expected result:
 
 ## Working in a group
 
-If you working in a group, we recommend that **all** team members read the [Working in a group guidelines](../working-in-a-group.md). Confirm all group members have read and understand these before starting to write code.
+If you working in a group, we recommend that **all** team members read the [Working in a group guidelines](https://github.com/CodeYourFuture/The-Piscine/blob/main/working-in-a-group.md). Confirm all group members have read and understand these before starting to write code.


### PR DESCRIPTION
So they work when embedding in other sites

This is a hack, but a useful one for today