### PR TITLE
Clarify the Spaced Repetition Tracker project requirements

### DIFF
--- a/Project-Spaced-Repetition-Tracker/README.md
+++ b/Project-Spaced-Repetition-Tracker/README.md
@@ -38,7 +38,7 @@ When a user is selected, you must get the stored data for that user and use it t
 
 If there is an agenda, your website should display a list of topics and the revision date when the user should revise in _chronological order_. For each revision date, it should display the date and the name of the topic to revise. Revision dates in the past should not be displayed.
 
-Your website must include a form with a text input, a date picker and submit button that allows a user to add a new topic. This form must be accessible, so for example, hitting the Enter key will also submit the topic name, the same as clicking the submit button.
+Your website must include a form with a text input, a date picker and submit button that allows a user to add a new topic. This form must be accessible, so for example, hitting the Enter key will also submit the topic name, the same as clicking the submit button. The form should validate that the topic name and date have be set by the user.
 
 The date picker should default to today’s date, but allow selection of another date. You should use the built-in date picker for browsers, unless attempted as a bonus task. **No credit** is given for using an alternative date picker.
 
@@ -59,6 +59,7 @@ All of the below requirements must be met for the project to be considered compl
 - If there is no agenda for the selected user, a message is displayed to explain this
 - The website must contain a form with inputs for a topic name and a date picker. The form should also have a submit button.
 - The date picker must default to today’s date on first page load
+- The form has validation to ensure that both the topic name and and selected date have been set by the user
 - Submitting the form adds a new topic to revise for the relevant user only. The topic’s dates to revise are calculated as one week, one month, three months, six months and one year from the selected date (see manual testing below)
 - After creating a new topic to revise, the agenda for the current user is shown, including the new topic
 - The website must score 100 for accessibility in Lighthouse

--- a/Project-Spaced-Repetition-Tracker/README.md
+++ b/Project-Spaced-Repetition-Tracker/README.md
@@ -14,7 +14,6 @@ Note that when running locally, in order to open a web page which uses modules, 
 
 We have also provided a `storage.js` file, which contains four functions to help with data storage. `storage.js` is a file containing four functions:
 
-- `getUserIds()`: when called, returns an array of strings, each of which is a user id
 - `getData(userId)`: when called with a user id string as an argument, returns an array of objects, each of which represents an agenda item for the user
 - `addData(userId, data)`: when called with a user id string and an array of objects as arguments, it will append the agenda items data to the user's stored agenda. Each of the objects should contain information about the agenda item, such as the date and topic that should be revised on that date. The function does not return anything
 - `clearData(userId)`: when called with a user id string as an argument, it will clear any stored data associated with the user id. This is provided to help with development, and is not required in the final code
@@ -50,6 +49,7 @@ Your GitHub repository must contain unit tests which demonstrate that your code 
 All of the below requirements must be met for the project to be considered complete:
 
 - The website must contain a drop-down which lists exactly 5 users
+- All of the users must have no agenda when starting from a "clean state" with no stored data
 - Selecting a user must display the agenda for the relevant user (see manual testing below)
 - If there is no agenda for the selected user, a message is displayed to explain this
 - The website must contain a form with inputs for a topic name and a date picker. The form should also have a submit button.
@@ -67,14 +67,14 @@ Where an instruction says `${YEAR}`, use that year. Where an instruction says `$
 
 Steps:
 
-1. Select User 1 from the drop-down
+1. Select user 1 from the drop-down
 1. Add “Functions in JS” to the text input
 1. Select the date 19th July ${YEAR} from the date picker
 1. Submit the form
 
 Expected result:
 
-- The agenda for User 1 is shown, with the revision dates shown as follows:
+- The agenda for user 1 is shown, with the revision dates shown as follows:
   - Functions in JS, 26th July ${YEAR}
   - Functions in JS, 19th August ${YEAR}
   - Functions in JS, 19th October ${YEAR}
@@ -85,7 +85,7 @@ Expected result:
 
 Steps:
 
-1. Select User 2 from the drop-down
+1. Select user 2 from the drop-down
 1. Add “Variables in Python” to the text input
 1. Select the date 5th November ${YEAR} from the date picker
 1. Submit the form
@@ -95,7 +95,7 @@ Steps:
 
 Expected result:
 
-- The agenda for User 2 is shown, with the revision dates shown as follows:
+- The agenda for user 2 is shown, with the revision dates shown as follows:
   - Functions in Python, 12th October ${YEAR}
   - Functions in Python, 5th November ${YEAR}
   - Variables in Python, 12th November ${YEAR}
@@ -118,7 +118,7 @@ Steps:
 
 Expected result:
 
-- The agenda for User 3 is shown, with the revision dates shown as follows:
+- The agenda for user 3 is shown, with the revision dates shown as follows:
   - (No topic is shown for 1 week after the selected date, as this is in the past)
   - Codewars, Today's date (1 month from the selected date)
   - Codewars, Two months in the future, on the same date of the month as today (3 months from the selected date)

--- a/Project-Spaced-Repetition-Tracker/README.md
+++ b/Project-Spaced-Repetition-Tracker/README.md
@@ -33,7 +33,7 @@ Your website must include a drop-down to select a user to display information fo
 
 You **must not** implement any kind of authentication. Just a drop-down to choose which user’s information to display. You **must not** implement data storage yourself, as we have provided that for you.
 
-After picking a user, your website should display the list of topics to revise in chronological order. For each revision date, it should display the date and the name of the topic to revise. Revision dates in the past should not be displayed.
+After picking a user, the user's goal is to understand which topic they should revise next. To do this, your website should display the list of topics to revise in _chronological order_. For each revision date, it should display the date and the name of the topic to revise. Revision dates in the past should not be displayed.
 
 Your website must include a form with a text input, a date picker and submit button that allows a user to add a new topic. This form must be accessible, so for example, hitting the Enter key will also submit the topic name, the same as clicking the submit button.
 

--- a/Project-Spaced-Repetition-Tracker/README.md
+++ b/Project-Spaced-Repetition-Tracker/README.md
@@ -2,7 +2,7 @@
 
 At Code Your Future, we like to use a learning technique called spaced repetition. The technique involves reviewing a topic over increasing time gaps (e.g. after one week, one month, three months, six months, one year).
 
-One of the difficulties of this approach is tracking which topic should be revised at what time. Your task is to write code which allows a user to track topics and show when they should revise these topics.
+One of the difficulties of this approach is tracking which topic should be revised at what time. Your task is to write code which allows a user to track topics and then understand which topic they should revise next.
 
 You should make a frontend, which displays an agenda of topics to revise on specific dates. You should use **HTML and JavaScript only**. You should **not** use CSS. We want to focus on your ability to create the correct logic and not spend time on creating the perfect UI.
 
@@ -28,17 +28,21 @@ You must submit both a link to your GitHub repo, and a link to the deployed webs
 
 Your website must be hosted on the internet, and must be automatically deployed when you merge changes to your GitHub repo.
 
-Your website must include a drop-down to select a user to display information for. When a user is selected, you must display the agenda for that user. If there is no agenda for the user, you should present a message explaining this.
+Your website must include a drop-down to select a user to display information for.
 
-You **must not** implement any kind of authentication. Just a drop-down to choose which user’s information to display. You **must not** implement data storage yourself, as we have provided that for you.
+You **must not** implement any kind of authentication. Just a drop-down to choose which user’s information to display. You **must not** implement data storage yourself, as we have provided that for you. (We want to avoid you "wasting" time implementing these, instead of building the project!)
 
-After picking a user, the user's goal is to understand which topic they should revise next. To do this, your website should display the list of topics to revise in _chronological order_. For each revision date, it should display the date and the name of the topic to revise. Revision dates in the past should not be displayed.
+The goal of your website to is allow users to understand which topic they should revise next.
+
+When a user is selected, you must get the stored data for that user and use it to display their agenda. If there is no agenda for the user, you should present a message explaining this.
+
+If there is an agenda, your website should display a list of topics and the revision date when the user should revise in _chronological order_. For each revision date, it should display the date and the name of the topic to revise. Revision dates in the past should not be displayed.
 
 Your website must include a form with a text input, a date picker and submit button that allows a user to add a new topic. This form must be accessible, so for example, hitting the Enter key will also submit the topic name, the same as clicking the submit button.
 
 The date picker should default to today’s date, but allow selection of another date. You should use the built-in date picker for browsers, unless attempted as a bonus task. **No credit** is given for using an alternative date picker.
 
-When the form is submitted, your website should calculate the date to revise for one week, one month, three months, six months and one year from the selected date. Using these calculations, your website should store the topic name and any necessary revision date data using the functions from `storage.js` as described above.
+When the form is submitted, your website should calculate the revision dates for that topic. There should be a revision date one week, one month, three months, six months and one year from the selected date. Using these calculations, your website should store the topic name and any necessary revision date data using the functions from `storage.js` as described above.
 
 After the new data has been stored, the updated agenda must be displayed (including the new topic) for the relevant user.
 
@@ -50,6 +54,7 @@ All of the below requirements must be met for the project to be considered compl
 
 - The website must contain a drop-down which lists exactly 5 users
 - All of the users must have no agenda when starting from a "clean state" with no stored data
+- Selecting a user must load the relevant user's agenda from storage
 - Selecting a user must display the agenda for the relevant user (see manual testing below)
 - If there is no agenda for the selected user, a message is displayed to explain this
 - The website must contain a form with inputs for a topic name and a date picker. The form should also have a submit button.

--- a/Project-Spaced-Repetition-Tracker/README.md
+++ b/Project-Spaced-Repetition-Tracker/README.md
@@ -53,6 +53,7 @@ Your GitHub repository must contain unit tests which demonstrate that your code 
 All of the below requirements must be met for the project to be considered complete:
 
 - The website must contain a drop-down which lists exactly 5 users
+- No user is selected on page load
 - All of the users must have no agenda when starting from a "clean state" with no stored data
 - Selecting a user must load the relevant user's agenda from storage
 - Selecting a user must display the agenda for the relevant user (see manual testing below)

--- a/Project-Spaced-Repetition-Tracker/README.md
+++ b/Project-Spaced-Repetition-Tracker/README.md
@@ -119,10 +119,11 @@ Steps:
 Expected result:
 
 - The agenda for User 3 is shown, with the revision dates shown as follows:
-  - Codewars, Today's date
-  - Codewars, Two months in the future (the same day of the month as today)
-  - Codewars, 5 months in the future (the same day of the month as today)
-  - Codewars, 11 months in the future (the same day of the month as today)
+  - (No topic is shown for 1 week after the selected date, as this is in the past)
+  - Codewars, Today's date (1 month from the selected date)
+  - Codewars, Two months in the future, on the same date of the month as today (3 months from the selected date)
+  - Codewars, 5 months in the future, on the same day of the month as today (6 months from the selected date)
+  - Codewars, 11 months in the future, on the same day of the month as today (1 year from the selected date)
 - Each of the revision dates show the topic name and the relevant date (styling/formatting does not matter as long as it is understandable)
 - The form remains on the website (allowing for further topics to be added)
 

--- a/Project-Spaced-Repetition-Tracker/storage.js
+++ b/Project-Spaced-Repetition-Tracker/storage.js
@@ -3,15 +3,6 @@
 // You should not need to modify it to complete the project.
 
 /**
- * Get a list of user ids
- *
- * @returns {string[]} List of user id strings
- */
-export function getUserIds() {
-  return ["1", "2", "3", "4", "5"];
-}
-
-/**
  * Get data associated with a specific user.
  *
  * @param {string} userId The user id to get data for


### PR DESCRIPTION
A few general clarifications of the Spaced Repetition Tracker spec, based on some observations from the first cohort completing it:

- Clarify that revision dates in the past should not be shown in the agenda
- Make the "user 3" instructions clear that the calculated time gaps are the same for selecting dates in the future or in the past
- Remove the `getUserIds` scaffolding, as it was only implicit that it should be used to generate the list of users. Removing it means that trainees won't over-complicate things by joining the simple list of ids with richer data (e.g. user names)
- Make it more explicit the user's agenda must be loaded from storage when a user is selected. Hopefully prevent cases where they inject data automatically
- Add form validation requirements. Most of the trainees in cohort 1 did this anyway, but I think it's good to be explicit
- Clarify that no user should be auto-selected on page load